### PR TITLE
Fix trait paths in macros

### DIFF
--- a/as_gd_res_derive/src/lib.rs
+++ b/as_gd_res_derive/src/lib.rs
@@ -62,7 +62,7 @@ fn expand_as_gd_res(input: DeriveInput) -> proc_macro2::TokenStream {
                     #(#defs)*
                 }
 
-                impl ExtractGd for #res_name {
+                impl ::as_gd_res::ExtractGd for #res_name {
                     type Extracted = #name;
                     fn extract(&self) -> Self::Extracted {
                         Self::Extracted {
@@ -145,7 +145,7 @@ fn expand_as_gd_res(input: DeriveInput) -> proc_macro2::TokenStream {
                         type GdArray = ::godot::prelude::Array<#res_name>;
                     }
 
-                    impl ExtractGd for dyn #dyn_trait {
+                    impl ::as_gd_res::ExtractGd for dyn #dyn_trait {
                         type Extracted = #name;
                         fn extract(&self) -> Self::Extracted {
                             self.extract_enum_variant()

--- a/as_gd_res_derive/src/tests.rs
+++ b/as_gd_res_derive/src/tests.rs
@@ -56,7 +56,7 @@ fn test_simple() {
           pub b: <f32 as ::as_gd_res::AsGdRes>::ResType,
       }
 
-      impl ExtractGd for SimpleStructParamsResource {
+      impl ::as_gd_res::ExtractGd for SimpleStructParamsResource {
           type Extracted = SimpleStructParams;
           fn extract(&self) -> Self::Extracted {
               Self::Extracted {
@@ -110,7 +110,7 @@ fn test_2() {
                 pub coin_scene_2: <OnEditorInit<PackedScenePath> as ::as_gd_res::AsGdRes>::ResType,
             }
 
-            impl ExtractGd for DropParams2Resource {
+            impl ::as_gd_res::ExtractGd for DropParams2Resource {
                 type Extracted = DropParams2;
                 fn extract(&self) -> Self::Extracted {
                     Self::Extracted {
@@ -172,7 +172,7 @@ fn test_attr_pass_through() {
           pub coin_scene_2: <OnEditorInit<PackedScenePath> as ::as_gd_res::AsGdRes>::ResType,
       }
 
-      impl ExtractGd for DropParams2Resource {
+      impl ::as_gd_res::ExtractGd for DropParams2Resource {
           type Extracted = DropParams2;
           fn extract(&self) -> Self::Extracted {
               Self::Extracted {
@@ -273,7 +273,7 @@ fn test_enum_with_data_variants() {
             type GdArray = ::godot::prelude::Array<PickupResource>;
         }
 
-        impl ExtractGd for dyn PickupResourceExtractVariant {
+        impl ::as_gd_res::ExtractGd for dyn PickupResourceExtractVariant {
             type Extracted = Pickup;
             fn extract(&self) -> Self::Extracted {
                 self.extract_enum_variant()
@@ -352,7 +352,7 @@ fn test_complex_nested_struct() {
             pub damage_team: <DamageTeam as ::as_gd_res::AsGdRes>::ResType,
         }
 
-        impl ExtractGd for EnemyParamsResource {
+        impl ::as_gd_res::ExtractGd for EnemyParamsResource {
             type Extracted = EnemyParams;
             fn extract(&self) -> Self::Extracted {
                 Self::Extracted {

--- a/as_simple_gd_enum_derive/src/lib.rs
+++ b/as_simple_gd_enum_derive/src/lib.rs
@@ -90,11 +90,11 @@ fn expand_as_gd_res(input: DeriveInput) -> proc_macro2::TokenStream {
                     #( #unit_variants , )*
                 }
 
-                impl AsSimpleGdEnum for #name {
+                impl ::as_gd_res::AsSimpleGdEnum for #name {
                     type GdEnumType = #res_name;
                 }
 
-                impl ExtractGd for #res_name {
+                impl ::as_gd_res::ExtractGd for #res_name {
                     type Extracted = #name;
                     fn extract(&self) -> Self::Extracted {
                         (*self).into()

--- a/as_simple_gd_enum_derive/src/tests.rs
+++ b/as_simple_gd_enum_derive/src/tests.rs
@@ -26,11 +26,11 @@ fn test_simple_enum() {
             Earth,
             Air,
         }
-        impl AsSimpleGdEnum for Element {
+        impl ::as_gd_res::AsSimpleGdEnum for Element {
             type GdEnumType = ElementAsGdEnum;
         }
 
-        impl ExtractGd for ElementAsGdEnum {
+        impl ::as_gd_res::ExtractGd for ElementAsGdEnum {
             type Extracted = Element;
             fn extract(&self) -> Self::Extracted {
                 (*self).into()


### PR DESCRIPTION
## Summary
- ensure derive macros qualify `ExtractGd` and `AsSimpleGdEnum`
- update tests to match new expansions

## Testing
- `cargo test` *(fails: could not download Rust toolchain)*