### PR TITLE
Fix typo in resource spec comment

### DIFF
--- a/as_gd_res/src/gen_resource_spec.rs
+++ b/as_gd_res/src/gen_resource_spec.rs
@@ -329,7 +329,7 @@ impl AsGdRes for BrainParams {
     type ResType = DynGd<Resource, dyn BrainParamsEnumDynEnumResource>;
 }
 
-// the `ExtractGd` impl for `DynGd<Resource, dyn #{enum_name}EnumDynRes>` will `dyn_bind` the dyn compatible Resouce, and call `extract_enum_data` on to get back the enum variant
+// the `ExtractGd` impl for `DynGd<Resource, dyn #{enum_name}EnumDynRes>` will `dyn_bind` the dyn compatible Resource, and call `extract_enum_data` to get back the enum variant
 impl ExtractGd for DynGd<Resource, dyn BrainParamsEnumDynEnumResource> {
     type Extracted = BrainParams;
     fn extract(&self) -> Self::Extracted {


### PR DESCRIPTION
## Summary
- correct a typo in `as_gd_res/src/gen_resource_spec.rs`

## Testing
- `cargo build --workspace --all-targets --verbose` *(fails: failed to load manifest for dependency `godot`)*
- `cargo test --workspace --all-targets --verbose` *(fails: failed to load manifest for dependency `godot`)*

------
https://chatgpt.com/codex/tasks/task_e_683781ea6dd48323a401d1013a56a353