### PR TITLE
Add union case test for AsSimpleGdEnum

### DIFF
--- a/as_simple_gd_enum_derive/src/tests.rs
+++ b/as_simple_gd_enum_derive/src/tests.rs
@@ -108,3 +108,22 @@ fn test_struct_error() {
 
     assert_eq!(expand_as_gd_res(input).to_string(), expected.to_string());
 }
+
+#[test]
+fn test_union_error() {
+    let input: syn::DeriveInput = parse_quote! {
+            pub union Foo {
+                a: u32,
+                b: f32,
+            }
+    };
+
+    let expected = quote! {
+
+                compile_error!(
+                    "AsSimpleGdEnum derive only supports enums with unit variants, not structs. Did you mean to derive `AsGdRes`?"
+                );
+    };
+
+    assert_eq!(expand_as_gd_res(input).to_string(), expected.to_string());
+}


### PR DESCRIPTION
## Summary
- test that unions produce the same compile_error as structs when deriving
  `AsSimpleGdEnum`

## Testing
- `cargo test -p as_simple_gd_enum_derive` *(fails: failed to load manifest for workspace member)*

------
https://chatgpt.com/codex/tasks/task_e_6837821381e88323bc689e971eaa8673