### PR TITLE
Fix typos in gen_resource_spec comments

### DIFF
--- a/as_gd_res/src/gen_resource_spec.rs
+++ b/as_gd_res/src/gen_resource_spec.rs
@@ -270,7 +270,7 @@ impl ExtractGd for RoombaBrainParamsResource {
 //
 
 ///// SIMPLE ENUMS
-/// Note that godod-rust does not support `Option<SomeEnum>`; If you want an "optional" enum, include a `None` variant in the enum itself, and set taht as the default value.
+/// Note that godot-rust does not support `Option<SomeEnum>`; If you want an "optional" enum, include a `None` variant in the enum itself, and set that as the default value.
 /// `Array<SomeEnum>` is also not supported
 
 // for a simple enum with no associated data, we generate an


### PR DESCRIPTION
## Summary
- correct typo in comment referencing godot-rust
- fix small spelling mistake

## Testing
- `cargo test --workspace` *(fails: failed to load manifest for dependency `godot`)*

------
https://chatgpt.com/codex/tasks/task_e_68378207528c83238400845bd7c00f55