### PR TITLE
Add script and workflow for resource output test

### DIFF
--- a/.github/workflows/resource_output_test.yml
+++ b/.github/workflows/resource_output_test.yml
@@ -1,0 +1,25 @@
+name: Resource Output Test
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Download Godot
+        run: |
+          curl -L https://github.com/godotengine/godot-builds/releases/download/4.4.1-stable/Godot_v4.4.1-stable_linux.x86_64.zip -o godot.zip
+          unzip godot.zip -d /usr/local/bin
+          echo "GODOT_BIN=/usr/local/bin/Godot_v4.4.1-stable_linux.x86_64" >> $GITHUB_ENV
+          chmod +x /usr/local/bin/Godot_v4.4.1-stable_linux.x86_64
+          sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Build extension
+        run: cargo build
+      - name: Run resource extract test
+        run: ./codex_scripts/test_resource_extract.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,14 @@ The integration tests live in `resource_test_godot_project/unit_test.gd` and use
    cd resource_test_godot_project
    xvfb-run ./addons/gdUnit4/runtest.sh -a res://unit_test.gd
    ```
+
+## Verifying resource extraction output
+The repository includes a helper script `codex_scripts/test_resource_extract.sh`
+which runs `test_scene.tscn` headlessly and compares the printed output with
+`expected_rust_print_output.txt`. Run this script after building the extension
+and setting `GODOT_BIN` to ensure the scene output matches the expected data:
+
+```bash
+export GODOT_BIN=/usr/local/bin/Godot_v4.4.1-stable_linux.x86_64
+./codex_scripts/test_resource_extract.sh
+```

--- a/codex_scripts/test_resource_extract.sh
+++ b/codex_scripts/test_resource_extract.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXPECTED="$REPO_ROOT/resource_test_godot_project/expected_rust_print_output.txt"
+OUTPUT=$(mktemp)
+
+if [ -z "${GODOT_BIN:-}" ]; then
+  echo "GODOT_BIN not set" >&2
+  exit 1
+fi
+
+xvfb-run "$GODOT_BIN" --headless --path "$REPO_ROOT/resource_test_godot_project" test_scene.tscn > "$OUTPUT"
+awk '/--- Resource Extract Test ---/{flag=1;next} flag' "$OUTPUT" > "$OUTPUT.trimmed"
+# remove trailing newline to match expected file
+truncate -s -1 "$OUTPUT.trimmed"
+diff -u "$EXPECTED" "$OUTPUT.trimmed"


### PR DESCRIPTION
## Summary
- add `test_resource_extract.sh` in `codex_scripts`
- document running the script in `AGENTS.md`
- add GitHub workflow to run the script automatically

## Testing
- `cargo test`
- `xvfb-run "$GODOT_BIN" --headless --editor --path resource_test_godot_project --quit`
- `xvfb-run ./addons/gdUnit4/runtest.sh -a res://unit_test.gd`
- `./codex_scripts/test_resource_extract.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fd865064c83238bf45c80392fbb0c