### PR TITLE
Improve output visibility in resource extract test

### DIFF
--- a/codex_scripts/test_resource_extract.sh
+++ b/codex_scripts/test_resource_extract.sh
@@ -17,4 +17,17 @@ xvfb-run "$GODOT_BIN" --headless --path "$REPO_ROOT/resource_test_godot_project"
 awk '/--- Resource Extract Test ---/{flag=1;next} flag' "$OUTPUT" > "$OUTPUT.trimmed"
 # remove trailing newline to match expected file
 truncate -s -1 "$OUTPUT.trimmed"
-diff -u "$EXPECTED" "$OUTPUT.trimmed"
+
+echo "--- Trimmed Output ---"
+cat "$OUTPUT.trimmed"
+
+echo "--- Diff with Expected ---"
+diff -u "$EXPECTED" "$OUTPUT.trimmed" || true
+
+if cmp -s "$EXPECTED" "$OUTPUT.trimmed"; then
+  echo "Output matches expected."
+  exit 0
+else
+  echo "Output differs from expected." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- print the trimmed output
- display the diff before doing the final comparison

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841f441e7e48323be324971c62c9a8b